### PR TITLE
Allow slashes in git branche/tag names

### DIFF
--- a/src/Webcreate/Vcs/Git.php
+++ b/src/Webcreate/Vcs/Git.php
@@ -328,7 +328,7 @@ class Git extends AbstractGit implements VcsInterface
             $branches = array();
             foreach ($list as $line) {
                 list ($hash, $ref) = explode("\t", $line);
-                $branches[] = new Reference(basename($ref), Reference::BRANCH, $hash);
+                $branches[] = new Reference(str_replace('refs/heads/', '', $ref), Reference::BRANCH, $hash);
             }
 
             $this->branches = $branches;
@@ -355,7 +355,7 @@ class Git extends AbstractGit implements VcsInterface
             $tags = array();
             foreach ($list as $line) {
                 list ($hash, $ref) = explode("\t", $line);
-                $tags[] = new Reference(basename($ref), Reference::TAG, $hash);
+                $tags[] = new Reference(str_replace('refs/tags/', '', $ref), Reference::TAG, $hash);
             }
 
             $this->tags = $tags;


### PR DESCRIPTION
Using basename function to guess a branch/tag name truncate every slash based name part.

Ex: refs/heads/foo/bar -> bar

This PR simply remove the "refs/heads/" part to guess the name

Ex: refs/heads/foo/bar -> foo/bar
