### PR TITLE
Newer log format has new filename after original name

### DIFF
--- a/src/Webcreate/Vcs/Git/Parser/CliParser.php
+++ b/src/Webcreate/Vcs/Git/Parser/CliParser.php
@@ -155,11 +155,15 @@ class CliParser implements ParserInterface
 
         $retval = array();
         foreach ($lines as $line) {
-            if (preg_match('/([ACDMRTUXB])\d*\s+(.*)?/', $line, $matches)) {
-                list($fullmatch, $x, $file) = $matches;
+            if (preg_match('/([ACDMRTUXB])(\d*)\s+(.*)?/', $line, $matches)) {
+                list($fullmatch, $status, $number, $filename) = $matches;
 
-                $file = new VcsFileInfo($file, $this->getClient()->getHead());
-                $file->setStatus($x);
+                if ($number && preg_match('/(.*\s)+(.*)/', $filename, $filenameMatches)) {
+                    list($fullmatch, $originalName, $filename) = $filenameMatches;
+                }
+
+                $file = new VcsFileInfo($filename, $this->getClient()->getHead());
+                $file->setStatus($status);
 
                 $retval[] = $file;
             } else {

--- a/tests/Webcreate/Vcs/Git/Parser/CliParserTest.php
+++ b/tests/Webcreate/Vcs/Git/Parser/CliParserTest.php
@@ -28,8 +28,11 @@ class CliParserTest extends \PHPUnit_Framework_TestCase
     {
         $diffOutput = <<<EOT
 A       tests/Webcreate/Vcs/Git/Parser/CliParserTest.php
-R       Webcreate/Vcs/Svn/WorkingCopy.php
-R062    Webcreate/Vcs/Svn/SvnAdmin.php
+R       Webcreate/Vcs/Svn/WorkingRename.php
+R062    Webcreate/Vcs/Svn/WorkingCopy.php    Webcreate/Vcs/Svn/WorkingRename.php
+D       Webcreate/Vcs/Svn/AbstractSvn.php
+M       Webcreate/Vcs/Svn.php
+M001    Webcreate/Vcs/Svn.php
 EOT;
 
         $parsedDiff = $this->parser->parseDiffOutput(
@@ -43,10 +46,22 @@ EOT;
 
         $fileInfo = next($parsedDiff);
         $this->assertSame('R', $fileInfo->getStatus());
-        $this->assertSame('Webcreate/Vcs/Svn/WorkingCopy.php', $fileInfo->getPathname());
+        $this->assertSame('Webcreate/Vcs/Svn/WorkingRename.php', $fileInfo->getPathname());
 
         $fileInfo = next($parsedDiff);
         $this->assertSame('R', $fileInfo->getStatus());
-        $this->assertSame('Webcreate/Vcs/Svn/SvnAdmin.php', $fileInfo->getPathname());
+        $this->assertSame('Webcreate/Vcs/Svn/WorkingRename.php', $fileInfo->getPathname());
+
+        $fileInfo = next($parsedDiff);
+        $this->assertSame('D', $fileInfo->getStatus());
+        $this->assertSame('Webcreate/Vcs/Svn/AbstractSvn.php', $fileInfo->getPathname());
+
+        $fileInfo = next($parsedDiff);
+        $this->assertSame('M', $fileInfo->getStatus());
+        $this->assertSame('Webcreate/Vcs/Svn.php', $fileInfo->getPathname());
+
+        $fileInfo = next($parsedDiff);
+        $this->assertSame('M', $fileInfo->getStatus());
+        $this->assertSame('Webcreate/Vcs/Svn.php', $fileInfo->getPathname());
     }
 }


### PR DESCRIPTION
Newer log format is properly supported now, newer filename was displayed after the original name.